### PR TITLE
Add extender to tool list

### DIFF
--- a/src/burp/ExtractorEditor.java
+++ b/src/burp/ExtractorEditor.java
@@ -68,6 +68,9 @@ public class ExtractorEditor {
 		ToolMenuItem repeater = new ToolMenuItem("Repeater", true);
 		toolSelectors.put(IBurpExtenderCallbacks.TOOL_REPEATER, repeater);
 		toolSelection.add(repeater);
+		ToolMenuItem extender = new ToolMenuItem("Extender", true);
+		toolSelectors.put(IBurpExtenderCallbacks.TOOL_EXTENDER, extender);
+		toolSelection.add(extender);
 		toolSelectionBar.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseClicked(MouseEvent e) {

--- a/src/burp/ExtractorEditor.java
+++ b/src/burp/ExtractorEditor.java
@@ -439,7 +439,8 @@ public class ExtractorEditor {
 				this.isToolSelected(IBurpExtenderCallbacks.TOOL_PROXY),
 				this.isToolSelected(IBurpExtenderCallbacks.TOOL_SCANNER),
 				this.isToolSelected(IBurpExtenderCallbacks.TOOL_INTRUDER),
-				this.isToolSelected(IBurpExtenderCallbacks.TOOL_REPEATER));
+				this.isToolSelected(IBurpExtenderCallbacks.TOOL_REPEATER),
+				this.isToolSelected(IBurpExtenderCallbacks.TOOL_EXTENDER));
 		String[] requestSelectionRegex = this.getSelectionRegex();
 		RequestResponseState state = new RequestResponseState(tools,
 				this.useSuiteScope(),
@@ -457,6 +458,7 @@ public class ExtractorEditor {
 		this.toolSelectors.get(IBurpExtenderCallbacks.TOOL_SCANNER).setSelected(state.inScopeTools.scanner);
 		this.toolSelectors.get(IBurpExtenderCallbacks.TOOL_INTRUDER).setSelected(state.inScopeTools.intruder);
 		this.toolSelectors.get(IBurpExtenderCallbacks.TOOL_REPEATER).setSelected(state.inScopeTools.repeater);
+		this.toolSelectors.get(IBurpExtenderCallbacks.TOOL_EXTENDER).setSelected(state.inScopeTools.extender);
 		this.useScope.setSelected(state.useSuiteScope);
 		this.useCustomHost.setSelected(!state.useSuiteScope);
 		this.targetHost.setText(state.targetHost);

--- a/src/burp/persistence/InScopeTools.java
+++ b/src/burp/persistence/InScopeTools.java
@@ -6,16 +6,19 @@ public class InScopeTools {
 	public boolean scanner;
 	public boolean intruder;
 	public boolean repeater;
+        public boolean extender;
 
 	public InScopeTools(boolean allTools,
 						boolean proxy,
 						boolean scanner,
 						boolean intruder,
-						boolean repeater) {
+                                                boolean repeater,
+						boolean extender) {
 		this.allTools = allTools;
 		this.proxy = proxy;
 		this.scanner = scanner;
 		this.intruder = intruder;
 		this.repeater = repeater;
+                this.extender = extender;
 	}
 }


### PR DESCRIPTION
During scanning some extensions put their payloads in it, but those requests are still marked as "Extender" tool. There is no "Extender" option in "Select in-scope tools" menu, and because of that token extraction (and insertion) stops work with requests issued by extensions. That leads to requests fails, that can be discovered only in the middle of the scan. 

I hope it should fix this problem, but I can't test my changes. Hope you do so, before accept pull request.

